### PR TITLE
Fixing tests in PetTypeFormatterTests.java

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
@@ -67,6 +67,18 @@ public class PetTypeFormatterTests {
 
     @Test(expected = ParseException.class)
     public void shouldThrowParseException() throws ParseException {
+        List<PetType> petTypes = new ArrayList<>();
+
+        PetType dogPetType = mock(PetType.class);
+        PetType birdPetType = mock(PetType.class);
+
+        when(dogPetType.getName()).thenReturn("Dog");
+        when(birdPetType.getName()).thenReturn("Bird");
+
+        petTypes.add(dogPetType);
+        petTypes.add(birdPetType);
+
+        Mockito.when(this.pets.findPetTypes()).thenReturn(petTypes);
         petTypeFormatter.parse("Fish", Locale.ENGLISH);
     }
 

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 /**
  * Test class for {@link PetTypeFormatter}
  *
@@ -47,35 +48,26 @@ public class PetTypeFormatterTests {
 
     @Test
     public void shouldParse() throws ParseException {
-        Mockito.when(this.pets.findPetTypes()).thenReturn(makePetTypes());
+        List<PetType> petTypes = new ArrayList<>();
+
+        PetType dogPetType = mock(PetType.class);
+        PetType birdPetType = mock(PetType.class);
+
+        when(dogPetType.getName()).thenReturn("Dog");
+        when(birdPetType.getName()).thenReturn("Bird");
+
+        petTypes.add(dogPetType);
+        petTypes.add(birdPetType);
+
+        Mockito.when(this.pets.findPetTypes()).thenReturn(petTypes);
+
         PetType petType = petTypeFormatter.parse("Bird", Locale.ENGLISH);
         assertEquals("Bird", petType.getName());
     }
 
     @Test(expected = ParseException.class)
     public void shouldThrowParseException() throws ParseException {
-        Mockito.when(this.pets.findPetTypes()).thenReturn(makePetTypes());
         petTypeFormatter.parse("Fish", Locale.ENGLISH);
-    }
-
-    /**
-     * Helper method to produce some sample pet types just for test purpose
-     *
-     * @return {@link Collection} of {@link PetType}
-     */
-    private List<PetType> makePetTypes() {
-        List<PetType> petTypes = new ArrayList<>();
-        petTypes.add(new PetType() {
-            {
-                setName("Dog");
-            }
-        });
-        petTypes.add(new PetType() {
-            {
-                setName("Bird");
-            }
-        });
-        return petTypes;
     }
 
 }


### PR DESCRIPTION

Problem Found:
 In PetTypeFormatterTests.java, these is a helper method called makePetTypes() that provides objects of type ‘petType’ for both, shouldParse() and shouldThrowParseException() methods. The problem is that whenever those methods are called, new instances of petType objects are created.
Fix:
Issue was fixed by creating mocks to replace PetType objects that were created for testing purposes.

